### PR TITLE
fix: Delete optim & lr argument in predict.yaml

### DIFF
--- a/configs/predict.yaml
+++ b/configs/predict.yaml
@@ -52,8 +52,6 @@ model:
   - 1
   activation: ReLU
   dropout: 0.15
-  optim: Adam
-  lr: 0.0001
 data:
   bprna_dir: null
   input_dir: null


### PR DESCRIPTION
```
$ python run.py predict
usage: run.py [-h] [-c CONFIG] [--print_config[=flags]] {fit,validate,test,predict} ...
error: Validation failed: Subcommand 'predict' does not accept nested key 'model.optim'
```

When I run prediction, above error was occured. So I removed `optim`, `lr` argument in `predict.yaml`